### PR TITLE
support nested if but drop nested each and for

### DIFF
--- a/test/specs/sections/combination.spec.js
+++ b/test/specs/sections/combination.spec.js
@@ -50,15 +50,18 @@ describe('using multiple sections at the same time', function () {
         expect(output).toBe('00-11');
     });
 
-    describe('nested each', function (expect) {
-        var output = Easybars('{{#each fruits}}{{name}}:{{#each colors}}{{@value}},{{/each}}{{/each}}', data);
-        expect(output).toBe('apple:red,green,banana:yellow,brown,kiwi:green,');
-    });
-
-    describe('nested for', function (expect) {
-        var output = Easybars('{{#for 2 fruits}}{{name}}:{{#for 1 colors}}{{@value}},{{/for}}{{/for}}', data);
-        expect(output).toBe('apple:red,banana:yellow,');
-    });
+    // This functionality is not yet supported. It will error if you try.
+    //     The problem is that providing the correct scope for variables within the inner block is really hard.
+    //
+    // describe('nested each', function (expect) {
+    //     var output = Easybars('{{#each fruits}}{{name}}:{{#each colors}}{{@value}},{{/each}}{{/each}}', data);
+    //     expect(output).toBe('apple:red,green,banana:yellow,brown,kiwi:green,');
+    // });
+    //
+    // describe('nested for', function (expect) {
+    //     var output = Easybars('{{#for 2 fruits}}{{name}}:{{#for 1 colors}}{{@value}},{{/for}}{{/for}}', data);
+    //     expect(output).toBe('apple:red,banana:yellow,');
+    // });
 
     describe('nested if', function (expect) {
         var output = Easybars('{{#if go}}{{#if fruits}}hello{{/if}}{{/if}}', data);

--- a/test/specs/sections/if.spec.js
+++ b/test/specs/sections/if.spec.js
@@ -95,8 +95,14 @@ describe('#if', function () {
         output = Easybars('{{#if go}}-{{food}}-{{/if}}-{{#if !go}}dog{{/if}}-{{#if go}}-{{food}}-{{/if}}', data);
         expect(output).toBe('-bun----bun-', 4);
 
-        output = Easybars('{{#if !go}}-{{food}}-{{/if}}-{{#if !go}}dog{{/if}}-{{#if !go}}-{{food}}-{{/if}}', data);
-        expect(output).toBe('--', 5);
+        output = Easybars('{{#if !go}}0{{food}}1{{/if}}2{{#if !go}}dog{{/if}}3{{#if !go}}4{{food}}5{{/if}}', data);
+        expect(output).toBe('23', 5);
+
+        output = Easybars('0{{#if go}}1{{#if go}}{{food}}{{/if}}2{{/if}}3{{#if go}}{{food}}{{/if}}4', data);
+        expect(output).toBe('01bun23bun4', 6);
+
+        output = Easybars('0{{#if go}}1{{/if}}3{{/if}}4', data);
+        expect(output).toBe('0134', 7); // bogus closing tags are dropped
     });
 
 });


### PR DESCRIPTION
We still had brittleness and bugs in our nested `#if` helpers...

For now, we can fix most of those and make everything feel more solid, but the current fix still does not allow for nested `#each` and `#for` helpers because the scopes for the inner variables is wrong. We can and will throw an error if a user attempts to use this unsupported nesting.

Given the usefulness of nested `#if` sections and the library as it is with this limited fix, we will move forward like this for now and investigate alternative approaches for lexing to help resolve this more broadly in future versions.