### PR TITLE
corwin: Improved tokenization; fixed custom delimiters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ var negateRE = new RegExp(/^(!?)(.*)$/);
  *
  * @returns {Array} tokens - The stream of tokens as an array
  **/
-function lex(string) {
+function lex(string, options) {
     // The token stream
     var tokens = [];
 
@@ -251,7 +251,7 @@ function lex(string) {
     // iterate over the string, pulling off leading text and the first token until there is
     // nothing left.
     while (string) {
-        string = doMatch(string, tokenRE, handleMatchResult);
+        string = doMatch(string, options.tokenRE || tokenRE, handleMatchResult);
     }
 
     return tokens;
@@ -290,7 +290,7 @@ function parse(string, data, options) {
      * @returns {string} The parsed string
      **/
     function parseString(string, data) {
-        return parseTokens(lex(string), data);
+        return parseTokens(lex(string, options), data);
     }
 
     /**

--- a/test/specs/custom.spec.js
+++ b/test/specs/custom.spec.js
@@ -17,11 +17,18 @@ describe('with custom settings', function () {
             '=': '0',
         },
         escape: ['"','8'],
-        removeUnmatched: true,
-        // tags: {
-        //     raw: ['<%=','%>'],
-        //     encoded: ['<%-','%>'],
-        // },
+        removeUnmatched: true
+    });
+
+    describe('use a custom token regex matcher', function(expect) {
+        var easybars = new Easybars({
+            tokenRE: new RegExp(/^([\s\S]*?)(\\"{{2,})([\s\S]*?)(}{2,}\\")([\s\S]*)$/),
+        });
+        var str = 'background-color: \"{{colorName}}\";';
+        var data = { colorName: 'green' };
+        var render = easybars.compile(str);
+        var output = render(data);
+        expect(output).toBe('background-color: green;');
     });
 
     describe('custom encodings and escaping work', function(expect) {

--- a/test/specs/custom.spec.js
+++ b/test/specs/custom.spec.js
@@ -22,7 +22,7 @@ describe('with custom settings', function () {
 
     describe('use a custom token regex matcher', function(expect) {
         var easybars = new Easybars({
-            tokenRE: new RegExp(/^([\s\S]*?)(\\"{{2,})([\s\S]*?)(}{2,}\\")([\s\S]*)$/),
+            tokenRE: '\\"({{2,3})([^{][\\s\\S]*?[^}])(}{2,3})\\"',
         });
         var str = 'background-color: \"{{colorName}}\";';
         var data = { colorName: 'green' };


### PR DESCRIPTION
This commit does three things. First, it improves the handling of the ambiguity
of encoded vs. non-encoded interpolations ({{{x}}} vs {{x}}). Second it breaks
the high-level tokenizer regex into three parts: prefix, token, and suffix. And
finally, it allows configuration of the token portion of the regex to allow for
custom delimiters. All of this is to make custom delimiters work, but also has
the benefit of reducing the fragility of the tokenization.

index.js:
  Split tokenRE into three strings representing the prefix, token and
    suffix. The prefix and suffix are defined as constants, but the token
    string is configured from the options via the new 'tokenRE' property.
  Added a 'tokenizer' parameter to lex() so that the high-level RegExp it users
    can be generated dynamically instead of being hard-coded. This is needed to
    support custom tokens.
  Improved the tokenRE by making it explicitly match only the actual
    delimiters, not arbitrary strings of braces. This allows the removal of the
    slice calls in handleMatchResult.
  Added an 'encodeDelimiters' property to the options, which consists of a two
    element array one for the open encode delimiter, and one for the close
    encode delimiter. Matching the actual delimiter found against the entries
    in this array is used to determine whether an interpolation should be encoded
    or not.
  Moved lexAction() into handleMatchResult() as this was easier than adding a
    context parameter to doMatch(). By using the handleMatchResult() context,
    lexAction() can determine whether or not to set the encode flag on an
    interpolation token without needing some fake tokenizing to be added to the
    token. This also simplifies actionRE.
  Modified lexAction() to add the actual delimiters it found when it records
    the 'original' property in an interpolation token. This allows the
    interpolate function to provide the correct delimiters if the interpolation
    fails, even if custom delimiters are used.
  Modified parse() to generate the tokenizer RegExp based on the options.

custom.spec.js:
  Reflected changes in the custom token regex test.