### PR TITLE
corwin/Jess: Fix an issue with conditionals inside of loops.

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,7 +446,6 @@ function parse(string, data, options) {
                         }
                         return savedTokens;
                     }
-                    continue;
                 }
 
                 savedTokens.push(token);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easybars",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "String templating made {{easy}}",
   "keywords": [
     "handlebars",

--- a/test/specs/sections/combination.spec.js
+++ b/test/specs/sections/combination.spec.js
@@ -76,4 +76,29 @@ describe('using multiple sections at the same time', function () {
         expect(output).toBe('00 01 apple:sweet 04,juicy 05, 02 banana:sweet 06,mushy 07,');
     });
 
+    describe('nested eaches and ifs with falsey conditionals', function (expect) {
+        var nestedFruitData = {
+            fruits: [
+                {
+                    color: 'red',
+                    name: 'apple',
+                },
+                {
+                    color: 'orange',
+                    name: 'tangerine',
+                },
+                {
+                    name: 'pear',
+                },
+                {
+                    color: 'purple',
+                    name: 'eggplant',
+                }
+            ],
+        };
+
+        var output = Easybars('{{#each fruits}}Fruit: {{#if color}}{{color}} {{/if}}{{name}}, {{/each}}', nestedFruitData);
+        var expected = 'Fruit: red apple, Fruit: orange tangerine, Fruit: pear, Fruit: purple eggplant, ';
+        expect(output).toBe(expected);
+    });
 });


### PR DESCRIPTION
findLoopBody() incorrectly stripped end tokens from non-loop constructs inside the loop body. This would result in failing conditionals causing subsequent constructs within the loop body to be incorrectly ignored.